### PR TITLE
Mod regex to only capture URL at end of message

### DIFF
--- a/scripts/dgshow.coffee
+++ b/scripts/dgshow.coffee
@@ -49,7 +49,7 @@ module.exports = (robot) ->
     num = "#{msg.match[1]}"
     showSearch msg, "%23#{num}%3A" 
 
-  robot.hear /(.*\w\t?)(http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+)(?!.)/i, (msg) ->
+  robot.hear /(.*\w\t?)(http[s]?:\/\/(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+)(?!.)/i, (msg) ->
       cardName = msg.match[1]
       cardUrl = msg.match[2]
       suggester = msg.message.user.name

--- a/scripts/dgshow.coffee
+++ b/scripts/dgshow.coffee
@@ -49,7 +49,7 @@ module.exports = (robot) ->
     num = "#{msg.match[1]}"
     showSearch msg, "%23#{num}%3A" 
 
-  robot.hear /(.*) (http.*)/i, (msg) ->
+  robot.hear /(.*\w\t?)(http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+)(?!.)/i, (msg) ->
       cardName = msg.match[1]
       cardUrl = msg.match[2]
       suggester = msg.message.user.name


### PR DESCRIPTION
Expanded regex for HTTP/S to provide better group separation. Match group 1 should include any and all text and white space up to the URL, URL must be followed by a newline to be captured in match group 2.  URLs anywhere else in the msg body will be ignored.
